### PR TITLE
Update edit list item to form

### DIFF
--- a/WebApi/Data/ListItemData.py
+++ b/WebApi/Data/ListItemData.py
@@ -46,7 +46,7 @@ class ListItemData(object):
             'listId': listItem["listId"], 
             'text': listItem["text"],
             'url': listItem["url"],
-            'completed': listItem["completed"],
+            'completed': listItem["completed"] if "completed" in listItem else False,
         })
         return result
     

--- a/WebApp/src/EditListItem/EditListItem.js
+++ b/WebApp/src/EditListItem/EditListItem.js
@@ -22,7 +22,7 @@ const EditListItem = (props) => {
     const [url, setUrl] = useState(props.item && props.item.url);
     const [description, setDescription] = useState(props.item && props.item.text);
     return(
-        <form onSubmit={() => props.onSave(description, url)} className = 'mainArea'>
+        <form onSubmit={() => props.onSave(description, url)} className = 'mainArea' data-testid = 'edit-form'>
             <TextField
                 label="Description"
                 margin="dense"

--- a/WebApp/src/EditListItem/EditListItem.js
+++ b/WebApp/src/EditListItem/EditListItem.js
@@ -22,7 +22,7 @@ const EditListItem = (props) => {
     const [url, setUrl] = useState(props.item && props.item.url);
     const [description, setDescription] = useState(props.item && props.item.text);
     return(
-        <div className = 'mainArea'>
+        <form onSubmit={() => props.onSave(description, url)} className = 'mainArea'>
             <TextField
                 label="Description"
                 margin="dense"
@@ -59,13 +59,13 @@ const EditListItem = (props) => {
                     variant="contained"
                     color="primary"
                     size="small"
-                    onClick={() => props.onSave(description, url)}
                     startIcon={<SaveIcon />}
+                    type="submit"
                 >
                     Save
                 </Button>
             </div>
-        </div>
+        </form>
     );
 }
 

--- a/WebApp/src/EditListItem/EditListItem.spec.js
+++ b/WebApp/src/EditListItem/EditListItem.spec.js
@@ -21,26 +21,26 @@ describe("Edit List Item", () => {
         renderEditListItem(jest.fn(), jest.fn(), testItem);
     });
 
-    it("fills description with editted item's text", () => {
-        const { getByLabelText, debug } = renderEditListItem(jest.fn(), jest.fn(), testItem);
+    it("fills description with edited item's text", () => {
+        const { getByLabelText } = renderEditListItem(jest.fn(), jest.fn(), testItem);
         const description = getByLabelText("editDescription");
         expect(description.querySelector("input").value).toBe(testItem.text);
     });
 
-    it("fills url with editted item's url", () => {
-        const { getByLabelText, debug } = renderEditListItem(jest.fn(), jest.fn(), testItem);
+    it("fills url with edited item's url", () => {
+        const { getByLabelText } = renderEditListItem(jest.fn(), jest.fn(), testItem);
         const url = getByLabelText("editUrl");
         expect(url.querySelector("input").value).toBe(testItem.url);
     });
 
     it("renders description with no value when null item passed in", () => {
-        const { getByLabelText, debug } = renderEditListItem(jest.fn(), jest.fn(), null);
+        const { getByLabelText } = renderEditListItem(jest.fn(), jest.fn(), null);
         const description = getByLabelText("editDescription");
         expect(description.querySelector("input").value).toBe('');
     });
 
     it("renders url with no value when null item passed in", () => {
-        const { getByLabelText, debug } = renderEditListItem(jest.fn(), jest.fn(), null);
+        const { getByLabelText } = renderEditListItem(jest.fn(), jest.fn(), null);
         const url = getByLabelText("editUrl");
         expect(url.querySelector("input").value).toBe('');
     })
@@ -65,11 +65,11 @@ describe("Edit List Item", () => {
         expect(onDelete).toBeCalled();
     });
 
-    it("calls onSave with description and url when save button is clicked", () => {
-        const onSave = jest.fn()
-        const { getByText } = renderEditListItem(onSave, jest.fn(), testItem);
-        const saveButton = getByText("Save");
-        fireEvent.click(saveButton);
-        expect(onSave).toBeCalledWith(testItem.text, testItem.url);
-    });
+    it("calls onSave with description and url when the form is submitted", () => {
+        const onSave = jest.fn();
+        const { getByTestId } = renderEditListItem(onSave, jest.fn(), testItem);
+        const form = getByTestId("edit-form");
+        fireEvent.submit(form);
+        expect(onSave).toBeCalledWith(testItem.text, testItem.url)
+    })
 });


### PR DESCRIPTION
**Purpose:** The purpose of this work was to convert the edit list item component to a form to enable keyboard accessibility. 
**Details of Changes:** Changed edit list item to a form component, added a test-id so I could write a test around submitting the form, and fixed an issue with the insert data operation that was broken from a recent PR.
**Testing Considerations:** Added a new jest test for submitting the form and making sure the callback receives the correct parameters.